### PR TITLE
Ignore deno lint for `qrcode.min.js` (#46)

### DIFF
--- a/.github/workflows/ci-code.yml
+++ b/.github/workflows/ci-code.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         deno-version: v2.x
     - name: Lint all js/ts files
-      run: deno lint
+      run: deno lint --ignore"**/qrcode.min.js"
 
 
   # Run all JS unit-tests by deno test


### PR DESCRIPTION
Close #46

## Checks

No checks for infra maintaining.
