### PR TITLE
Participant-count packet direction mistake (#63)

### DIFF
--- a/designs/packet-protocols.md
+++ b/designs/packet-protocols.md
@@ -24,8 +24,8 @@
 >
 > (\*) Value is little endian. To get original value: `array[1] | (array[2] << 8)`
 
-| Type              | ID   | Direction             | Value                                |
-| ----------------- | ---- | --------------------- | ------------------------------------ |
-| Participant count | 0x21 | participant <- server | Count of all participant             |
-| Survey start      | 0x22 | moderator -> server   | Duration of survey response          |
-| Survey result     | 0x23 | moderator <- server   | Count of 'Yes' responded participant |
+| Type              | ID   | Direction           | Value                                |
+| ----------------- | ---- | ------------------- | ------------------------------------ |
+| Participant count | 0x21 | moderator <- server | Count of all participant             |
+| Survey start      | 0x22 | moderator -> server | Duration of survey response          |
+| Survey result     | 0x23 | moderator <- server | Count of 'Yes' responded participant |


### PR DESCRIPTION
Close #63

## Checks

- [x] Build or lint has passed
